### PR TITLE
移除已存在 message 无法覆盖的错误

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -133,9 +133,6 @@ class Validation {
       throw new TypeError('Message should be a string');
     }
     const messages = this.constructor.messages();
-    if (messages[name]) {
-      throw new Error(`Message ${name} has existed. Use validate function param instead.`);
-    }
     messages[name] = message;
   }
 }

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -1017,10 +1017,6 @@ describe('validation', () => {
       expect(() => {
         validation.addMessage('captcha', () => {});
       }).toThrowError('Message should be a string');
-      expect(() => {
-        validation.addMessage('required', 'another message');
-      }).toThrowError('Message required has existed. Use validate function param instead.');
     });
   });
 });
-


### PR DESCRIPTION
这个验证没有意义，比如想给 `required` 做一个全局的中文 message 就没法实现。